### PR TITLE
Use per-instance cookie jar

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ class MWBot {
 
             },
             timeout: 120000, // 120 seconds
-            jar: true,
+            jar: request.jar(),
             time: true,
             json: true
         };


### PR DESCRIPTION
When calling request library with jar: true it reuses a shared
global cookie jar. This causes session tokens to be shared between
MWBot instances. Create a cookie jar per MWBot instance to keep
them properly isolated.