### PR TITLE
Update read method, add bot properties where needed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -471,18 +471,24 @@ class MWBot {
      * Reads the content / and meta-data of one (or many) wikipages
      *
      * @param {string}  title    For multiple Pages use: PageA|PageB|PageC
+     * @param {boolean} redirect    If the page is a redirection, follow it or stay in the page 
      * @param {object}      [customRequestOptions]
      *
      * @returns {bluebird}
      */
-    read(title, customRequestOptions) {
-        return this.request({
+    read(title, redirect, customRequestOptions) {
+        let params = {
             action: 'query',
             prop: 'revisions',
             rvprop: 'content',
             titles: title,
-            redirects: 'yes'
-        }, customRequestOptions);
+        }
+
+        if (redirect) {
+            params.redirect = "redirect"
+        }
+
+        return this.request(params, customRequestOptions);
     }
 
     /**
@@ -501,7 +507,8 @@ class MWBot {
             title: title,
             text: content,
             summary: summary || this.options.defaultSummary,
-            token: this.editToken
+            token: this.editToken,
+            bot: true
         }, customRequestOptions);
     }
 
@@ -522,6 +529,7 @@ class MWBot {
             text: content,
             summary: summary || this.options.defaultSummary,
             nocreate: true,
+            bot: true,
             token: this.editToken
         }, customRequestOptions);
     }
@@ -540,29 +548,20 @@ class MWBot {
             action: 'delete',
             title: title,
             reason: reason || this.options.defaultSummary,
-            token: this.editToken
+            token: this.editToken,
+            bot: true
         }, customRequestOptions);
     }
-    
-    /**
-    * Moves a wiki page
-    *
-    * @param {string}  oldName
-    * @param {string}  newName
-    * @param {string}  [reason]
-    * @param {object}      [customRequestOptions]
-    *
-    * @returns {bluebird}
-    */
 
-    move(oldName, newName, reason, customRequestOptions) {
+    move(oldTitle, newTitle, reason, customRequestOptions) {
         return this.request({
             action: 'move',
-            from: oldName,
-            to: newName,
+            from: oldTitle,
+            to: newTitle,
             reason: reason || this.options.defaultSummary,
             token: this.editToken,
-        }, customRequestOptions);
+            bot: true
+        }, customRequestOptions)
     }
 
     /**
@@ -586,7 +585,8 @@ class MWBot {
                 filename: title || path.basename(pathToFile),
                 file: file,
                 comment: comment || '',
-                token: this.editToken
+                token: this.editToken,
+                bot: true
             }, customParams);
 
             let uploadRequestOptions = MWBot.merge(this.globalRequestOptions, {


### PR DESCRIPTION
According to the MediaWiki API reference, any request that includes the property "bot" with a truthy value will be treated as a request coming from a bot (woah!), and as such will be listed (let's say, in the Recent Changes page) as a bot action.
For the read method, I had come across occasions where I had to move a page then i.e. delete the page I was moving from (that was transformed into a redirect page). If you specify that you do not want to follow a redirection, it should be from the added "redirects" property in the read method. But because it isn't mandatory to follow any of these two behaviors, it is up to the botmaster to decide whether it should be the case or not.