### PR TITLE
Add method for read page with props

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ bot.read('Test Page|MediaWiki:Sidebar', {timeout: 8000}).then((response) => {
 });
 ```
 
+#### readWithProps(title, props, redirect, customRequestOptions)
+Reads the content and meta-data of one (or many) wikipages based on specific parameters.
+To fetch more than one page, separate the page names with `|`. To define multiple props separate them also with `|`.
+* See https://www.mediawiki.org/wiki/API:Query
+```js
+bot.readWithProps('Test Page|MediaWiki:Sidebar', 'user|userid|content', true, {timeout: 8000}).then((response) => {
+    // Success
+    console.log(response.query.pages['1']['revisions'][0]['*']);
+}).catch((err) => {
+    // Error
+});
+```
+
 #### update(title, content, summary, customRequestOptions)
 Updates a wiki page. If the page doesn't exist, it will fail. 
 * See https://www.mediawiki.org/wiki/API:Edit

--- a/src/index.js
+++ b/src/index.js
@@ -492,6 +492,31 @@ class MWBot {
     }
 
     /**
+     * Reads the content / and meta-data of one (or many) wikipages based on specific parameters
+     *
+     * @param {string}  title    For multiple Pages use: PageA|PageB|PageC
+     * @param {string}  props    For multiple Props use: user|userid|content
+     * @param {boolean} redirect    If the page is a redirection, follow it or stay in the page
+     * @param {object}      [customRequestOptions]
+     *
+     * @returns {bluebird}
+     */
+    readWithProps(title, props, redirect, customRequestOptions) {
+        let params = {
+            action: 'query',
+            prop: 'revisions',
+            rvprop: props,
+            titles: title
+        }
+
+        if (!redirect) {
+            params.redirect = "redirect"
+        }
+
+        return this.request(params, customRequestOptions);
+    }
+
+    /**
      * Edits a new wiki pages. Creates a new page if it does not exist yet.
      *
      * @param {string}  title


### PR DESCRIPTION
This pull request adds a possibility to get page data based on specific parameters. With the help of this new function, the desired data can be put together individually. The current existing `read()` function sends only limited data.

For example with `readWithProps('page name', 'user|userid')` you can get the user data of the last revision. 

I'm using this new function, maybe someone else needs it.