### PR TITLE
Add `updateFromID` function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -560,6 +560,28 @@ class MWBot {
     }
 
     /**
+     * Updates existing wiki pages. Does not create new ones.
+     *
+     * @param {number}  pageid
+     * @param {string}  content
+     * @param {string}  [summary]
+     * @param {object}      [customRequestOptions]
+     *
+     * @returns {bluebird}
+     */
+    updateFromID(pageid, content, summary, customRequestOptions) {
+        return this.request({
+            action: 'edit',
+            pageid: pageid,
+            text: content,
+            summary: summary || this.options.defaultSummary,
+            nocreate: true,
+            bot: true,
+            token: this.editToken
+        }, customRequestOptions);
+    }
+
+    /**
      * Deletes a new wiki page
      *
      * @param {string}  title


### PR DESCRIPTION
Allow editing a page based on the pageid, rather than the title. This only works for editing existing pages, so only duplicate `update` as `updateFromID` (since pages cannot be created by pageid)