### PR TITLE
Convert `read` into wrapper, add `readFromID`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -470,6 +470,8 @@ class MWBot {
     /**
      * Reads the content / and meta-data of one (or many) wikipages
      *
+     * Wrapper for readWithProps
+     *
      * @param {string}  title    For multiple Pages use: PageA|PageB|PageC
      * @param {boolean} redirect    If the page is a redirection, follow it or stay in the page
      * @param {object}      [customRequestOptions]
@@ -477,22 +479,13 @@ class MWBot {
      * @returns {bluebird}
      */
     read(title, redirect, customRequestOptions) {
-        let params = {
-            action: 'query',
-            prop: 'revisions',
-            rvprop: 'content',
-            titles: title
-        }
-
-        if (!redirect) {
-            params.redirect = "redirect"
-        }
-
-        return this.request(params, customRequestOptions);
+        return this.readWithProps(title, 'content', redirect, customRequestOptions);
     }
     
     /**
      * Reads the content / and meta-data of one (or many) wikipages
+     *
+     * Wrapper for readWithPropsFromID
      *
      * @param {number}  pageid    For multiple Pages use: PageA|PageB|PageC
      * @param {boolean} redirect    If the page is a redirection, follow it or stay in the page
@@ -501,18 +494,7 @@ class MWBot {
      * @returns {bluebird}
      */
     readFromID(pageid, redirect, customRequestOptions) {
-        let params = {
-            action: 'query',
-            prop: 'revisions',
-            rvprop: 'content',
-            pageids: pageid
-        }
-
-        if (!redirect) {
-            params.redirect = "redirect"
-        }
-
-        return this.request(params, customRequestOptions);
+        return this.readWithPropsFromID(pageid, 'content', redirect, customRequestOptions);
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -490,6 +490,30 @@ class MWBot {
 
         return this.request(params, customRequestOptions);
     }
+    
+    /**
+     * Reads the content / and meta-data of one (or many) wikipages
+     *
+     * @param {number}  pageid    For multiple Pages use: PageA|PageB|PageC
+     * @param {boolean} redirect    If the page is a redirection, follow it or stay in the page
+     * @param {object}      [customRequestOptions]
+     *
+     * @returns {bluebird}
+     */
+    readFromID(pageid, redirect, customRequestOptions) {
+        let params = {
+            action: 'query',
+            prop: 'revisions',
+            rvprop: 'content',
+            pageids: pageid
+        }
+
+        if (!redirect) {
+            params.redirect = "redirect"
+        }
+
+        return this.request(params, customRequestOptions);
+    }
 
     /**
      * Reads the content / and meta-data of one (or many) wikipages based on specific parameters
@@ -507,6 +531,31 @@ class MWBot {
             prop: 'revisions',
             rvprop: props,
             titles: title
+        }
+
+        if (!redirect) {
+            params.redirect = "redirect"
+        }
+
+        return this.request(params, customRequestOptions);
+    }
+
+    /**
+     * Reads the content / and meta-data of one (or many) wikipages based on specific parameters
+     *
+     * @param {number}  pageid    For multiple Pages use: PageA|PageB|PageC
+     * @param {string}  props    For multiple Props use: user|userid|content
+     * @param {boolean} redirect    If the page is a redirection, follow it or stay in the page
+     * @param {object}      [customRequestOptions]
+     *
+     * @returns {bluebird}
+     */
+    readWithPropsFromID(pageid, props, redirect, customRequestOptions) {
+        let params = {
+            action: 'query',
+            prop: 'revisions',
+            rvprop: props,
+            pageids: pageid
         }
 
         if (!redirect) {


### PR DESCRIPTION
Convert `read` into a wrapper for `readWithProps`, add `readFromID` and `readWithPropsFromID` to allow reading pages based on the page id rather than the title.