### PR TITLE
Remove login successful message

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -324,7 +324,6 @@ class MWBot {
                 if (response.login && response.login.result === 'Success') {
                     this.state = MWBot.merge(this.state, response.login);
                     this.loggedIn = true;
-                    log('[S] [MWBOT] Login successful: ' + loginString);
                     return resolve(this.state);
                 } else {
                     let reason = 'Unknown reason';


### PR DESCRIPTION
AFAICT, this is the only success message logged, and it would be nice to remove
from logs generated in CI.

An alternative would be to have an option for whether this should be added to
the log, but removing this seems like it wouldn't be that controversial.